### PR TITLE
Move drivetrain refactor to the Bunnybots 2019 branch

### DIFF
--- a/pathfinder/AbstractDrive.java
+++ b/pathfinder/AbstractDrive.java
@@ -1,271 +1,59 @@
 package org.frc5587.lib.pathfinder;
 
-import com.ctre.phoenix.motion.MotionProfileStatus;
-import com.ctre.phoenix.motion.SetValueMotionProfile;
-import com.ctre.phoenix.motion.TrajectoryPoint;
-import com.ctre.phoenix.motorcontrol.ControlMode;
-import com.ctre.phoenix.motorcontrol.IMotorController;
-import com.ctre.phoenix.motorcontrol.NeutralMode;
-import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
-import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 import com.kauailabs.navx.frc.AHRS;
 
-import org.frc5587.lib.TitanDrive;
-import org.frc5587.lib.TitanDrive.DriveSignal;
-
 import edu.wpi.first.wpilibj.GyroBase;
-import edu.wpi.first.wpilibj.Notifier;
-import edu.wpi.first.wpilibj.command.Subsystem;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
-public abstract class AbstractDrive extends Subsystem {
-    protected TalonSRX leftMaster, rightMaster;
-    protected IMotorController leftSlave, rightSlave;
-    protected GyroBase gyro;
-    protected AHRS ahrs;
+interface AbstractDrive {
 
-    private double maxVelocity = 2500; // Max velocity in STU
-    private int timeoutMS = 10;
-    public int stuPerRev, stuPerInch, minBufferCount;
-    public double wheelDiameterMeters;
+    public void setGyro(GyroBase gyro);
 
-    private MotionProfileStatus[] statuses = { new MotionProfileStatus(), new MotionProfileStatus() };
-    public Notifier profileNotifer = new Notifier(new ProcessProfileRunnable());
+    public void setAHRS(AHRS ahrs);
 
-    public AbstractDrive(TalonSRX leftMaster, TalonSRX rightMaster, IMotorController leftSlave,
-            IMotorController rightSlave, boolean flipRight) {
-        // Set motors to correct objects and connect the masters and slaves
-        this.leftMaster = leftMaster;
-        this.leftSlave = leftSlave;
-        this.rightMaster = rightMaster;
-        this.rightSlave = rightSlave;
-        leftSlave.follow(leftMaster);
-        rightSlave.follow(rightMaster);
+    public void setConstants(double maxVelocity, int timeoutMS, double wheelDiameterMeters, int minBufferCount);
 
-        // Left should not be reversed
-        leftMaster.setInverted(false);
-        leftSlave.setInverted(false);
-
-        // Invert the right side of the drivetrain
-        if (flipRight) {
-            rightMaster.setInverted(true);
-            rightSlave.setInverted(true);
-        } else {
-            // The Talon might have been used in reversed state in past, so just to be sure
-            rightMaster.setInverted(false);
-            rightSlave.setInverted(false);
-        }
-
-        // Set encoder rotation as opposite direction relative to motor rotation
-        this.leftMaster.setSensorPhase(true);
-        this.rightMaster.setSensorPhase(true);
-
-        this.ahrs = null;
-        this.gyro = null;
-
-        configPID(0);
-        configSettings();
-        enableBrakeMode(true);
-    }
-
-    public void setGyro(GyroBase gyro) {
-        this.gyro = gyro;
-    }
-
-    public void setAHRS(AHRS ahrs) {
-        this.ahrs = ahrs;
-    }
-
-    public void setConstants(double maxVelocity, int timeoutMS, int stuPerRev, int stuPerInch,
-            double wheelDiameterMeters, int minBufferCount) {
-        this.maxVelocity = maxVelocity;
-        this.timeoutMS = timeoutMS;
-        this.stuPerRev = stuPerRev;
-        this.stuPerInch = stuPerInch;
-        this.wheelDiameterMeters = wheelDiameterMeters;
-        this.minBufferCount = minBufferCount;
-    }
-
-    public abstract void configPID(int slot);
-
-    public abstract void configSettings();
-
-    public void enableBrakeMode(boolean enabled) {
-        if (enabled) {
-            leftMaster.setNeutralMode(NeutralMode.Brake);
-            rightMaster.setNeutralMode(NeutralMode.Brake);
-            leftSlave.setNeutralMode(NeutralMode.Brake);
-            rightSlave.setNeutralMode(NeutralMode.Brake);
-        } else {
-            leftMaster.setNeutralMode(NeutralMode.Coast);
-            rightMaster.setNeutralMode(NeutralMode.Coast);
-            leftSlave.setNeutralMode(NeutralMode.Coast);
-            rightSlave.setNeutralMode(NeutralMode.Coast);
-        }
-    }
+    public void enableBrakeMode(boolean enabled);
 
     /* --- BASIC MANUAL CONTROL CODE --- */
 
-    public void vbusCurve(double throttle, double curve, boolean isQuickTurn) {
-        DriveSignal d = TitanDrive.curvatureDrive(throttle, curve, isQuickTurn);
+    public void vbusCurve(double throttle, double curve, boolean isQuickTurn);
 
-        leftMaster.set(ControlMode.PercentOutput, d.left);
-        rightMaster.set(ControlMode.PercentOutput, d.right);
-    }
+    public void vbusArcade(double throttle, double turn);
 
-    public void vbusArcade(double throttle, double turn) {
-        DriveSignal d = TitanDrive.arcadeDrive(throttle, turn);
+    public void vbusLR(double left, double right);
 
-        leftMaster.set(ControlMode.PercentOutput, d.left);
-        rightMaster.set(ControlMode.PercentOutput, d.right);
-    }
+    public void velocityCurve(double throttle, double curve, boolean isQuickTurn);
 
-    public void vbusLR(double left, double right) {
-        leftMaster.set(ControlMode.PercentOutput, left);
-        rightMaster.set(ControlMode.PercentOutput, right);
-    }
+    public void velocityArcade(double throttle, double turn);
 
-    public void velocityCurve(double throttle, double curve, boolean isQuickTurn) {
-        DriveSignal d = TitanDrive.curvatureDrive(throttle, curve, isQuickTurn);
-
-        leftMaster.set(ControlMode.Velocity, d.left * maxVelocity);
-        rightMaster.set(ControlMode.Velocity, d.right * maxVelocity);
-    }
-
-    public void velocityArcade(double throttle, double turn) {
-        DriveSignal d = TitanDrive.arcadeDrive(throttle, turn);
-
-        leftMaster.set(ControlMode.Velocity, d.left * maxVelocity);
-        rightMaster.set(ControlMode.Velocity, d.right * maxVelocity);
-    }
-
-    public void stop() {
-        leftMaster.neutralOutput();
-        rightMaster.neutralOutput();
-    }
+    public void stop();
 
     /* --- MOTION PROFILE HANDLING CODE --- */
 
-    public class ProcessProfileRunnable implements java.lang.Runnable {
-        public void run() {
-            leftMaster.processMotionProfileBuffer();
-            rightMaster.processMotionProfileBuffer();
-        }
-    }
-
-    public void resetMP() {
-        leftMaster.clearMotionProfileHasUnderrun(timeoutMS);
-        leftMaster.clearMotionProfileTrajectories();
-        leftMaster.changeMotionControlFramePeriod(10);
-        leftMaster.configMotionProfileTrajectoryPeriod(10, timeoutMS);
-        leftMaster.setStatusFramePeriod(StatusFrameEnhanced.Status_10_MotionMagic, 10, timeoutMS);
-        leftMaster.set(ControlMode.MotionProfile, SetValueMotionProfile.Disable.value);
-
-        rightMaster.clearMotionProfileHasUnderrun(timeoutMS);
-        rightMaster.clearMotionProfileTrajectories();
-        rightMaster.changeMotionControlFramePeriod(10);
-        rightMaster.configMotionProfileTrajectoryPeriod(10, timeoutMS);
-        rightMaster.setStatusFramePeriod(StatusFrameEnhanced.Status_10_MotionMagic, 10, timeoutMS);
-        rightMaster.set(ControlMode.MotionProfile, SetValueMotionProfile.Disable.value);
-    }
-
-    public void updateStatus() {
-        leftMaster.getMotionProfileStatus(statuses[0]);
-        rightMaster.getMotionProfileStatus(statuses[1]);
-    }
-
-    public boolean isMPReady() {
-        boolean leftReady = getStatuses()[0].btmBufferCnt > minBufferCount;
-        boolean rightReady = getStatuses()[0].btmBufferCnt > minBufferCount;
-        return leftReady && rightReady;
-    }
-
-    public boolean isMPDone() {
-        boolean leftDone = getStatuses()[0].isLast;
-        boolean rightDone = getStatuses()[0].isLast;
-        return leftDone && rightDone;
-    }
-
-    public void queuePoints(TrajectoryPoint[][] trajectories) {
-        for (TrajectoryPoint point : trajectories[0]) {
-            leftMaster.pushMotionProfileTrajectory(point);
-        }
-        for (TrajectoryPoint point : trajectories[1]) {
-            rightMaster.pushMotionProfileTrajectory(point);
-        }
-    }
-
-    public void setProfileMode(SetValueMotionProfile mpMode) {
-        leftMaster.set(ControlMode.MotionProfile, mpMode.value);
-        rightMaster.set(ControlMode.MotionProfile, mpMode.value);
-    }
-
     /* --- UTILITY METHODS --- */
 
-    public void resetEncoders() {
-        leftMaster.setSelectedSensorPosition(0, 0, timeoutMS);
-        rightMaster.setSelectedSensorPosition(0, 0, timeoutMS);
-    }
+    public void resetEncoders();
 
-    public void sendDebugInfo() {
-        SmartDashboard.putNumber("Left Distance", getLeftPosition());
-        SmartDashboard.putNumber("Right Distance", getRightPosition());
-        SmartDashboard.putNumber("Left Velocity", getLeftVelocity());
-        SmartDashboard.putNumber("Right Velocity", getRightVelocity());
-        SmartDashboard.putNumber("Heading", getHeading());
-    }
+    public void sendDebugInfo();
 
-    public void sendMPDebugInfo() {
-        SmartDashboard.putNumber("Left Expected Pos", leftMaster.getActiveTrajectoryPosition());
-        SmartDashboard.putNumber("Right Expected Pos", rightMaster.getActiveTrajectoryPosition());
-        SmartDashboard.putNumber("Left Expected Vel", leftMaster.getActiveTrajectoryVelocity());
-        SmartDashboard.putNumber("Right Expected Vel", rightMaster.getActiveTrajectoryVelocity());
-    }
+    public void sendMPDebugInfo();
 
     /* --- GETTER METHODS --- */
 
-    public int getLeftPosition() {
-        return leftMaster.getSelectedSensorPosition(0);
-    }
+    public int getLeftPosition();
 
-    public int getRightPosition() {
-        return rightMaster.getSelectedSensorPosition(0);
-    }
+    public int getRightPosition();
 
-    public int getLeftVelocity() {
-        return leftMaster.getSelectedSensorVelocity(0);
-    }
+    public int getLeftVelocity();
 
-    public int getRightVelocity() {
-        return rightMaster.getSelectedSensorVelocity(0);
-    }
+    public int getRightVelocity();
 
-    public double getLeftVoltage() {
-        return leftMaster.getMotorOutputVoltage();
-    }
+    public double getLeftVoltage();
 
-    public double getRightVoltage() {
-        return rightMaster.getMotorOutputVoltage();
-    }
+    public double getRightVoltage();
 
-    public double getHeading() {
-        if (ahrs != null) {
-            return ahrs.getAngle();
-        } else if (gyro != null) {
-            return gyro.getAngle();
-        } else {
-            System.out.println(
-                    "Neither the AHRS nor a Gyro were set for the drivetrain before attempting to read heading");
-            return Double.NaN;
-        }
-    }
+    public double getHeading();
 
-    public double getHeading(Double wrapValue) {
-        var heading = getHeading() % 360;
-        return ((heading > 180.0) ? (heading - 360.0) : ((heading < -180.0) ? (heading + 360.0) : heading));
-    }
+    public double getHeading(Double wrapValue);
 
-    public MotionProfileStatus[] getStatuses() {
-        return statuses;
-    }
 }

--- a/pathfinder/GyroCompMPRunner.java
+++ b/pathfinder/GyroCompMPRunner.java
@@ -10,7 +10,7 @@ import jaci.pathfinder.Trajectory;
 import jaci.pathfinder.followers.EncoderFollower;
 
 public class GyroCompMPRunner extends Command {
-    private AbstractDrive drive;
+    private PhoenixAbstractDrive drive;
     private EncoderFollower lEncoderFollower, rEncoderFollower;
     private Notifier looper;
     private String name = "Anonymous Trajectory";
@@ -18,36 +18,36 @@ public class GyroCompMPRunner extends Command {
     private PIDVA pidvaLeft, pidvaRight;
     private double wheelDiameterMeters, initialHeading = 0;
 
-    public GyroCompMPRunner(AbstractDrive drive, String pathName, Pathgen pathgen, PIDVA pidvaLeft, PIDVA pidvaRight,
+    public GyroCompMPRunner(PhoenixAbstractDrive drive, String pathName, Pathgen pathgen, PIDVA pidvaLeft, PIDVA pidvaRight,
             double gyrokP) {
         this(drive, Pathgen.getTrajectoryFromFile(pathName), true, pathgen, pidvaLeft, pidvaRight, gyrokP);
         name = pathName;
     }
 
-    public GyroCompMPRunner(AbstractDrive drive, String pathName, boolean forwards, Pathgen pathgen, PIDVA pidvaLeft,
+    public GyroCompMPRunner(PhoenixAbstractDrive drive, String pathName, boolean forwards, Pathgen pathgen, PIDVA pidvaLeft,
             PIDVA pidvaRight, double gyrokP) {
         this(drive, Pathgen.getTrajectoryFromFile(pathName), forwards, pathgen, pidvaLeft, pidvaRight, gyrokP);
         name = pathName;
     }
 
-    public GyroCompMPRunner(AbstractDrive drive, Trajectory trajectory, Pathgen pathgen, PIDVA pidvaLeft,
+    public GyroCompMPRunner(PhoenixAbstractDrive drive, Trajectory trajectory, Pathgen pathgen, PIDVA pidvaLeft,
             PIDVA pidvaRight, double gyrokP) {
         this(drive, trajectory, true, pathgen, pidvaLeft, pidvaRight, gyrokP);
     }
 
-    public GyroCompMPRunner(AbstractDrive drive, Trajectory trajectory, boolean forwards, Pathgen pathgen,
+    public GyroCompMPRunner(PhoenixAbstractDrive drive, Trajectory trajectory, boolean forwards, Pathgen pathgen,
             PIDVA pidvaLeft, PIDVA pidvaRight, double gyrokP) {
         this(drive, pathgen.getLeftSide(trajectory), pathgen.getRightSide(trajectory), forwards, pidvaLeft, pidvaRight,
                 gyrokP);
         System.out.println("Trajectory length: " + trajectory.length());
     }
 
-    public GyroCompMPRunner(AbstractDrive drive, Trajectory leftTraj, Trajectory rightTraj, PIDVA pidvaLeft,
+    public GyroCompMPRunner(PhoenixAbstractDrive drive, Trajectory leftTraj, Trajectory rightTraj, PIDVA pidvaLeft,
             PIDVA pidvaRight, double gyrokP) {
         this(drive, leftTraj, rightTraj, true, pidvaLeft, pidvaRight, gyrokP);
     }
 
-    public GyroCompMPRunner(AbstractDrive drive, Trajectory leftTraj, Trajectory rightTraj, boolean forwards,
+    public GyroCompMPRunner(PhoenixAbstractDrive drive, Trajectory leftTraj, Trajectory rightTraj, boolean forwards,
             PIDVA pidvaLeft, PIDVA pidvaRight, double gyrokP) {
         requires(drive);
 

--- a/pathfinder/MotionProfileFiller.java
+++ b/pathfinder/MotionProfileFiller.java
@@ -13,12 +13,12 @@ import org.frc5587.lib.pathfinder.TalonPath;
 import edu.wpi.first.wpilibj.command.Command;
 
 public class MotionProfileFiller extends Command {
-    AbstractDrive drive;
+    PhoenixAbstractDrive drive;
     Pathgen pathgen;
     String profileName;
     TrajectoryPoint[][] profiles;
 
-    public MotionProfileFiller(AbstractDrive drive, Pathgen pathgen, String profileName, boolean zeroTalonDistance) {
+    public MotionProfileFiller(PhoenixAbstractDrive drive, Pathgen pathgen, String profileName, boolean zeroTalonDistance) {
         this.profileName = profileName;
         this.drive = drive;
 

--- a/pathfinder/MotionProfileRunner.java
+++ b/pathfinder/MotionProfileRunner.java
@@ -5,10 +5,10 @@ import com.ctre.phoenix.motion.SetValueMotionProfile;
 import edu.wpi.first.wpilibj.command.Command;
 
 public class MotionProfileRunner extends Command {
-    AbstractDrive drive;
+    PhoenixAbstractDrive drive;
     boolean ready = false;
 
-    public MotionProfileRunner(AbstractDrive drivetrain) {
+    public MotionProfileRunner(PhoenixAbstractDrive drivetrain) {
         this.drive = drivetrain;
         requires(drivetrain);
     }

--- a/pathfinder/PhoenixAbstractDrive.java
+++ b/pathfinder/PhoenixAbstractDrive.java
@@ -1,0 +1,271 @@
+package org.frc5587.lib.pathfinder;
+
+import com.ctre.phoenix.motion.MotionProfileStatus;
+import com.ctre.phoenix.motion.SetValueMotionProfile;
+import com.ctre.phoenix.motion.TrajectoryPoint;
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.IMotorController;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
+import com.ctre.phoenix.motorcontrol.can.TalonSRX;
+import com.kauailabs.navx.frc.AHRS;
+
+import org.frc5587.lib.TitanDrive;
+import org.frc5587.lib.TitanDrive.DriveSignal;
+
+import edu.wpi.first.wpilibj.GyroBase;
+import edu.wpi.first.wpilibj.Notifier;
+import edu.wpi.first.wpilibj.command.Subsystem;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+public abstract class PhoenixAbstractDrive extends Subsystem implements AbstractDrive {
+    protected TalonSRX leftMaster, rightMaster;
+    protected IMotorController leftSlave, rightSlave;
+    protected GyroBase gyro;
+    protected AHRS ahrs;
+
+    private double maxVelocity = 2500; // Max velocity in STU
+    private int timeoutMS = 10;
+    public int stuPerRev, stuPerInch, minBufferCount;
+    public double wheelDiameterMeters;
+
+    private MotionProfileStatus[] statuses = { new MotionProfileStatus(), new MotionProfileStatus() };
+    public Notifier profileNotifer = new Notifier(new ProcessProfileRunnable());
+
+    public PhoenixAbstractDrive(TalonSRX leftMaster, TalonSRX rightMaster, IMotorController leftSlave,
+            IMotorController rightSlave, boolean flipRight) {
+        // Set motors to correct objects and connect the masters and slaves
+        this.leftMaster = leftMaster;
+        this.leftSlave = leftSlave;
+        this.rightMaster = rightMaster;
+        this.rightSlave = rightSlave;
+        leftSlave.follow(leftMaster);
+        rightSlave.follow(rightMaster);
+
+        // Left should not be reversed
+        leftMaster.setInverted(false);
+        leftSlave.setInverted(false);
+
+        // Invert the right side of the drivetrain
+        if (flipRight) {
+            rightMaster.setInverted(true);
+            rightSlave.setInverted(true);
+        } else {
+            // The Talon might have been used in reversed state in past, so just to be sure
+            rightMaster.setInverted(false);
+            rightSlave.setInverted(false);
+        }
+
+        // Set encoder rotation as opposite direction relative to motor rotation
+        this.leftMaster.setSensorPhase(true);
+        this.rightMaster.setSensorPhase(true);
+
+        this.ahrs = null;
+        this.gyro = null;
+
+        configPID(0);
+        configSettings();
+        enableBrakeMode(true);
+    }
+
+    public void setGyro(GyroBase gyro) {
+        this.gyro = gyro;
+    }
+
+    public void setAHRS(AHRS ahrs) {
+        this.ahrs = ahrs;
+    }
+
+    public void setConstants(double maxVelocity, int timeoutMS, int stuPerRev, int stuPerInch,
+            double wheelDiameterMeters, int minBufferCount) {
+        this.maxVelocity = maxVelocity;
+        this.timeoutMS = timeoutMS;
+        this.stuPerRev = stuPerRev;
+        this.stuPerInch = stuPerInch;
+        this.wheelDiameterMeters = wheelDiameterMeters;
+        this.minBufferCount = minBufferCount;
+    }
+
+    public abstract void configPID(int slot);
+
+    public abstract void configSettings();
+
+    public void enableBrakeMode(boolean enabled) {
+        if (enabled) {
+            leftMaster.setNeutralMode(NeutralMode.Brake);
+            rightMaster.setNeutralMode(NeutralMode.Brake);
+            leftSlave.setNeutralMode(NeutralMode.Brake);
+            rightSlave.setNeutralMode(NeutralMode.Brake);
+        } else {
+            leftMaster.setNeutralMode(NeutralMode.Coast);
+            rightMaster.setNeutralMode(NeutralMode.Coast);
+            leftSlave.setNeutralMode(NeutralMode.Coast);
+            rightSlave.setNeutralMode(NeutralMode.Coast);
+        }
+    }
+
+    /* --- BASIC MANUAL CONTROL CODE --- */
+
+    public void vbusCurve(double throttle, double curve, boolean isQuickTurn) {
+        DriveSignal d = TitanDrive.curvatureDrive(throttle, curve, isQuickTurn);
+
+        leftMaster.set(ControlMode.PercentOutput, d.left);
+        rightMaster.set(ControlMode.PercentOutput, d.right);
+    }
+
+    public void vbusArcade(double throttle, double turn) {
+        DriveSignal d = TitanDrive.arcadeDrive(throttle, turn);
+
+        leftMaster.set(ControlMode.PercentOutput, d.left);
+        rightMaster.set(ControlMode.PercentOutput, d.right);
+    }
+
+    public void vbusLR(double left, double right) {
+        leftMaster.set(ControlMode.PercentOutput, left);
+        rightMaster.set(ControlMode.PercentOutput, right);
+    }
+
+    public void velocityCurve(double throttle, double curve, boolean isQuickTurn) {
+        DriveSignal d = TitanDrive.curvatureDrive(throttle, curve, isQuickTurn);
+
+        leftMaster.set(ControlMode.Velocity, d.left * maxVelocity);
+        rightMaster.set(ControlMode.Velocity, d.right * maxVelocity);
+    }
+
+    public void velocityArcade(double throttle, double turn) {
+        DriveSignal d = TitanDrive.arcadeDrive(throttle, turn);
+
+        leftMaster.set(ControlMode.Velocity, d.left * maxVelocity);
+        rightMaster.set(ControlMode.Velocity, d.right * maxVelocity);
+    }
+
+    public void stop() {
+        leftMaster.neutralOutput();
+        rightMaster.neutralOutput();
+    }
+
+    /* --- MOTION PROFILE HANDLING CODE --- */
+
+    public class ProcessProfileRunnable implements java.lang.Runnable {
+        public void run() {
+            leftMaster.processMotionProfileBuffer();
+            rightMaster.processMotionProfileBuffer();
+        }
+    }
+
+    public void resetMP() {
+        leftMaster.clearMotionProfileHasUnderrun(timeoutMS);
+        leftMaster.clearMotionProfileTrajectories();
+        leftMaster.changeMotionControlFramePeriod(10);
+        leftMaster.configMotionProfileTrajectoryPeriod(10, timeoutMS);
+        leftMaster.setStatusFramePeriod(StatusFrameEnhanced.Status_10_MotionMagic, 10, timeoutMS);
+        leftMaster.set(ControlMode.MotionProfile, SetValueMotionProfile.Disable.value);
+
+        rightMaster.clearMotionProfileHasUnderrun(timeoutMS);
+        rightMaster.clearMotionProfileTrajectories();
+        rightMaster.changeMotionControlFramePeriod(10);
+        rightMaster.configMotionProfileTrajectoryPeriod(10, timeoutMS);
+        rightMaster.setStatusFramePeriod(StatusFrameEnhanced.Status_10_MotionMagic, 10, timeoutMS);
+        rightMaster.set(ControlMode.MotionProfile, SetValueMotionProfile.Disable.value);
+    }
+
+    public void updateStatus() {
+        leftMaster.getMotionProfileStatus(statuses[0]);
+        rightMaster.getMotionProfileStatus(statuses[1]);
+    }
+
+    public boolean isMPReady() {
+        boolean leftReady = getStatuses()[0].btmBufferCnt > minBufferCount;
+        boolean rightReady = getStatuses()[0].btmBufferCnt > minBufferCount;
+        return leftReady && rightReady;
+    }
+
+    public boolean isMPDone() {
+        boolean leftDone = getStatuses()[0].isLast;
+        boolean rightDone = getStatuses()[0].isLast;
+        return leftDone && rightDone;
+    }
+
+    public void queuePoints(TrajectoryPoint[][] trajectories) {
+        for (TrajectoryPoint point : trajectories[0]) {
+            leftMaster.pushMotionProfileTrajectory(point);
+        }
+        for (TrajectoryPoint point : trajectories[1]) {
+            rightMaster.pushMotionProfileTrajectory(point);
+        }
+    }
+
+    public void setProfileMode(SetValueMotionProfile mpMode) {
+        leftMaster.set(ControlMode.MotionProfile, mpMode.value);
+        rightMaster.set(ControlMode.MotionProfile, mpMode.value);
+    }
+
+    /* --- UTILITY METHODS --- */
+
+    public void resetEncoders() {
+        leftMaster.setSelectedSensorPosition(0, 0, timeoutMS);
+        rightMaster.setSelectedSensorPosition(0, 0, timeoutMS);
+    }
+
+    public void sendDebugInfo() {
+        SmartDashboard.putNumber("Left Distance", getLeftPosition());
+        SmartDashboard.putNumber("Right Distance", getRightPosition());
+        SmartDashboard.putNumber("Left Velocity", getLeftVelocity());
+        SmartDashboard.putNumber("Right Velocity", getRightVelocity());
+        SmartDashboard.putNumber("Heading", getHeading());
+    }
+
+    public void sendMPDebugInfo() {
+        SmartDashboard.putNumber("Left Expected Pos", leftMaster.getActiveTrajectoryPosition());
+        SmartDashboard.putNumber("Right Expected Pos", rightMaster.getActiveTrajectoryPosition());
+        SmartDashboard.putNumber("Left Expected Vel", leftMaster.getActiveTrajectoryVelocity());
+        SmartDashboard.putNumber("Right Expected Vel", rightMaster.getActiveTrajectoryVelocity());
+    }
+
+    /* --- GETTER METHODS --- */
+
+    public int getLeftPosition() {
+        return leftMaster.getSelectedSensorPosition(0);
+    }
+
+    public int getRightPosition() {
+        return rightMaster.getSelectedSensorPosition(0);
+    }
+
+    public int getLeftVelocity() {
+        return leftMaster.getSelectedSensorVelocity(0);
+    }
+
+    public int getRightVelocity() {
+        return rightMaster.getSelectedSensorVelocity(0);
+    }
+
+    public double getLeftVoltage() {
+        return leftMaster.getMotorOutputVoltage();
+    }
+
+    public double getRightVoltage() {
+        return rightMaster.getMotorOutputVoltage();
+    }
+
+    public double getHeading() {
+        if (ahrs != null) {
+            return ahrs.getAngle();
+        } else if (gyro != null) {
+            return gyro.getAngle();
+        } else {
+            System.out.println(
+                    "Neither the AHRS nor a Gyro were set for the drivetrain before attempting to read heading");
+            return Double.NaN;
+        }
+    }
+
+    public double getHeading(Double wrapValue) {
+        var heading = getHeading() % 360;
+        return ((heading > 180.0) ? (heading - 360.0) : ((heading < -180.0) ? (heading + 360.0) : heading));
+    }
+
+    public MotionProfileStatus[] getStatuses() {
+        return statuses;
+    }
+}


### PR DESCRIPTION
There have been some pretty profound changes to the `bunnybots2019` branch since the `renaming-files` branch was created from it, but having just one branch will make cherry picking changes from the Bunnybots 2019 competition easier and I think the changes in the two branches belong together.

I'm not sure how easy the actual merge will be, but I think it really needs to happen anyway so that the changes in this branch don't get lost in time.